### PR TITLE
Added template event to article meta data

### DIFF
--- a/com.woltlab.wcf/templates/article.tpl
+++ b/com.woltlab.wcf/templates/article.tpl
@@ -53,6 +53,8 @@
 				{if ARTICLE_ENABLE_VISIT_TRACKING && $article->isNew()}<li><span class="badge label newMessageBadge">{lang}wcf.message.new{/lang}</span></li>{/if}
 				
 				<li class="articleLikesBadge"></li>
+				
+				{event name='contentHeaderMetaData'}
 			</ul>
 			
 			<meta itemprop="mainEntityOfPage" content="{$canonicalURL}">


### PR DESCRIPTION
I added a template event to the article meta data for those who what to render additional data like aggregated reviews, share data, etc

Regarding the article header I only could find template events which allows the developer to add new navigation buttons.

Since the contribution guideline doesn't mention the need of an issue, I omitted this additional effort.

